### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/GIT_USER_ID/GIT_REPO_ID
+module github.com/BL0CK-X/theblockchainapi-go-wrapper
 
 go 1.13
 


### PR DESCRIPTION
Previously `go get` would fail with msg:

```
module declares its path as: github.com/GIT_USER_ID/GIT_REPO_ID
but was required as: github.com/BL0CK-X/theblockchainapi-go-wrapper
```